### PR TITLE
Aragon One: 2019 mid update

### DIFF
--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -19,8 +19,8 @@ The goal is to build an identity experience that is seamless and allows individu
 
 Focus areas for this initiative:
 
-- **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization.
-
+- ✅ **Custom labels**: Easily tag any Ethereum address on the client. Also easily share tags with other people via a file or a link.
+- 🔜 **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization. [Autark](https://github.com/aragon/flock/blob/master/teams/Autark/2019Q1-2.md) is the one leading this initiative, and we will support via design and code reviews.
 - **Organization identity & membership support**: Allow users to create and manage their organizations’ profiles, providing an intuitive way to add members to a given organization and granting them permissions & privileges.
 
 Related GitHub issues:
@@ -30,7 +30,7 @@ Related GitHub issues:
 <https://github.com/aragon/design/issues/13>
 <https://github.com/aragon/design/issues/5>
 
-### I02 – Agent application
+### 🔜 I02 – Agent application
 
 This application will enable organizations to interact natively with other web3 applications (including other Aragon organizations).
 
@@ -44,11 +44,8 @@ The App Center will allow users to discover, get and manage apps developed by Ar
 
 Focus areas for this initiative:
 
-- **Upgrading apps**: Provide users with a secure way to install new app versions, fixes for features or enhancements to already installed/in use apps.
-
+- ✅ **Upgrading apps**: Provide users with a secure way to install new app versions, fixes for features or enhancements to already installed/in use apps.
 - **Browsing, installing & uninstalling apps**: Enhance app discovery and app management for end users.
-
-- **Monetization/incentivisation model for app developers**: Provide app developers with different monetisation models to create revenue from the apps they publish in the Aragon App Center.
 
 Related GitHub issues: 
 <https://github.com/aragon/design/issues/17>
@@ -64,19 +61,15 @@ Focus areas for this initiative:
 
 - **UI for conditional permissions**: the ACL in aragonOS 4 supports conditional permissions through permission parametrization, the Permissions app should display and allow to edit parameters.
 
-- **Budgeting app**: Enable organizations to plan and control their financial resources by setting time based permissions like budgeting.
+- 🔜 **Budgeting app**: Enable organizations to plan and control their financial resources by setting time based permissions like budgeting.
 
 [Related GitHub issue](https://github.com/aragon/aragonOS/issues/340)
 
-### I05 – Responsive experience
+### ✅ I05 – Responsive experience
 
 Improve the overall user experience of the platform and core apps by making the UI render well on any form factor, mobile wallet and browser, so users can seamlessly create, access and manage organizations.
 
-Focus areas for this initiative:
-
-- **Responsive UI**: Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
-
-- **Native mobile app**: Build native (probably React Native makes the most sense) mobile Aragon clients so we can benefit from device and OS specific capabilities.
+Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
 
 [Related GitHub issue](https://github.com/aragon/design/issues/4)
 
@@ -86,8 +79,8 @@ The aim of this initiative is to lower the barrier of entry for adoption by allo
 
 Focus areas for this initiative:
 
-- Meta-transactions & relayers
-- Improving onboarding for organizations
+- 🔜 Meta-transactions & relayers
+- 🔜 Improving onboarding for organizations
 
 [Related GitHub issue](https://github.com/aragon/aragonOS/pull/442)
 
@@ -98,9 +91,7 @@ Redesign the current voting architecture and experience to accommodate new votin
 Focus areas for this initiative:
 
 - **Voting with ERC20 tokens**: Enable users to vote using ERC20 tokens.
-
 - **Solidify Research on Transaction and Vote relayers as a network service**: Current research has shown that Meta-transactions and EVM storage proofs could provide a way to improve the cost and user experience of voting by relying on a network of bonded transaction and vote relayers. This research would explore the potential of Transaction and Vote Relaying as another fee generating service maintained by the Aragon Network.
-
 - **UX & technical research**: Create a plan to research the needs and run a pilot with 0x – Use case: AGP-1 + Representative Council(s)
 - Research and develop new Voting mechanisms.
 
@@ -112,7 +103,7 @@ Aragon Agreements are a core component of the Aragon Network, they enable users 
 
 #### Proposal agreements
 
-Proposal Agreements enhance the Aragon Client enabling organizations to leverage agreements to improve governance outcomes by requiring members to collateralized an agreement in order to submit proposals. Subjective proposal agreements can help avoid 51% attacks in DAOs by making sure that only proposals that are valid by the organization’s charter can be voted on and executed.
+Proposal Agreements enhance the Aragon client enabling organizations to leverage agreements to improve governance outcomes by requiring members to collateralized an agreement in order to submit proposals. Subjective proposal agreements can help avoid 51% attacks in DAOs by making sure that only proposals that are valid by the organization’s charter can be voted on and executed.
 
 #### Aragon Court
 
@@ -122,9 +113,44 @@ The Aragon Court is a service protocol designed to incentivize honest arbitratio
 
 ANT is intended to be used for governance and as the native currency for the network. In order to optimize ANT for these uses adjustments to ANT’s monetary policy may be necessary. This research would (1) explore the impact of creating a liquidity reserve and treasury bonds to tightly couple the networks assets with the valuation of ANT and (2) the feasibility of shifting the realization value appreciation to unit count rather than unit price using a scalar value token structure.
 
+### I09 – Caching on the Aragon client
+
+#### 🔜 Enhance aragonJS caching
+
+Make sure that aragonJS provides a much better caching mechanism, so the first load is slightly faster, and subsequent loads are much faster than they are now.
+
+#### 🔜 Experiment and implement centralized/decentralized hybrid for first-load
+
+Even enhancing aragonJS caching, the first load may still take a while. That's why it makes sense to experiment with centralized/decentralized hybrid solutions for it. For example, a trusted set of participants in the DAO could decide what the state was a at a given block, and then everyone would start loading from that. Then over time the client could sync locally and arrive to a fully decentralized/trustless state.
+
+### 🔜 I10 – Email notifications
+
+All actions on DAOs are irreversible and some of them may involve funds, so notifications become very important to the DAO's stakeholders.
+
+We will implement opt-in notifications using an email server and another server which will track all DAO-related events on Ethereum.
+
+### 🔜 I11 – Aragon client re-design and general enhancements
+
+We plan to re-design the Aragon client by creating a new Aragon Human Interface Guidelines that standardizes how to create Aragon apps.
+
+As part of this re-design, we will also re-design the following items, based on user feedback:
+
+- The Permissions app
+- The Voting app
+
+### 🔜 I12 – Support Aragon Funraising development
+
+We commit to supporting [Aragon Black](https://github.com/aragon/flock/blob/master/teams/Aragon%20Black/2019%20-%20Q3%20%26%20Q4.md) on their efforts to create the Aragon Fundraising app.
+
+This includes:
+
+- Designing the whole app
+- Doing code reviews
+- Assist in implementing a fundraising template on the Aragon client
+
 ### aragonOS
 
-#### Global emergency failsafe
+#### 🔜 Global emergency failsafe
 
 Provide an opt-in failsafe for organizations and individual apps to safely freeze their state during times of emergency
 
@@ -140,7 +166,7 @@ Rather than being a core part of aragonOS, aragonPM is a use case that is built 
 
 ### aragonSDK
 
-#### Continuously improve developer experience
+#### ✅ Continuously improve developer experience
 
 We should reduce time for developers to start using the aragonSDK (<https://github.com/aragon/aragon-cli/issues/203>) and also add features they request to it.
 
@@ -148,11 +174,7 @@ We should reduce time for developers to start using the aragonSDK (<https://gith
 
 Provide more APIs for Aragon app developers to use, including both UI controls (e.g. notifications, toast messages) as well as messaging and data controls (e.g. network state, action triggers). Aragon apps should also be extended to allow for multiple contracts to be used with one frontend (“monolithic apps”).
 
-#### Split aragonUI and Lorikeet
-
-Push Lorikeet as an ecosystem-wide project, while still providing an Aragon-opinionated experience with aragonUI.
-
-#### Maintain developer documentation and port it over to the new website design system
+#### ✅ Maintain developer documentation and port it over to the new website design system
 
 Take care of reviewing developer documentation when needed, and design and implement a new developer portal that aligns with the current design system we use for aragon.org.
 
@@ -249,68 +271,50 @@ The team is fully remote and distributed across the world, primarily in Europe a
 
 ### Current team
 
-The current full-time team is comprised of 16 people, distributed as follows:
+The current full-time team is comprised of 17 people, distributed as follows:
 
-- Development: 6
+- Development: 7
 
   - Brett: [GitHub](https://github.com/sohkai)
   - Pierre: [GitHub](https://github.com/bpierre)
   - Bingen: [GitHub](https://github.com/bingen)
   - Delfi: [GitHub](https://github.com/delfipolito)
   - Gorka: [GitHub](https://github.com/AquiGorka)
-  - Paul: [GitHub](https://github.com/drcmda)
-
-- Product Management and UX: 1
-
-  - Paty: [Github](https://github.com/dizzypaty), [Twitter](https://twitter.com/dizzypaty), [website](http://patydavila.com/)
-
+  - Facu: [GitHub](https://github.com/facuspagnuolo)
+- Daniel: [GitHub](https://github.com/2color)
 - Community and Communications: 2
 
   - Tatu: [GitHub](https://github.com/Smokyish), [Twitter](https://twitter.com/Smokyish), [LinkedIn](https://www.linkedin.com/in/smokyish/)
   - John: [GitHub](https://github.com/john-light), [Twitter](https://twitter.com/lightcoin), [LinkedIn](https://www.linkedin.com/in/lightcoin/)
-  
 - HR: 1
   - Monica: [Twitter](https://twitter.com/monicazng), [LinkedIn](https://www.linkedin.com/in/roumonicazeng)
-
-- Ops: 1
-
-  - Alexa: [GitHub](https://github.com/alexarwr), [Twitter,](https://twitter.com/alexa_rwr) [LinkedIn](https://www.linkedin.com/in/alexarwr/)
-
 - Research: 2
 
-- - Jorge: [GitHub](https://github.com/izqui), [Twitter](https://twitter.com/izqui9)
+  - Jorge: [GitHub](https://github.com/izqui), [Twitter](https://twitter.com/izqui9)
   - Luke: [GitHub](https://github.com/lkngtn), [Twitter](https://twitter.com/lkngtn), [LinkedIn](https://www.linkedin.com/in/lukasduncan/)
+- Design: 2
 
-- Product Design: 1
-
-  - Jouni: [GitHub](https://github.com/jounih), [Twitter](https://twitter.com/dharmaone), [LinkedIn](https://www.linkedin.com/in/jounihelminen/)
-
+  - Paty: [Github](https://github.com/dizzypaty), [Twitter](https://twitter.com/dizzypaty), [website](https://www.linkedin.com/in/jounihelminen/)
+  - Adri: [Twitter](https://twitter.com/owisixseven), [Behance](https://www.behance.net/owi_sixseven)
 - Ecosystem Development: 1
 
   - Maria: [GitHub](https://github.com/mariapao), [Twitter](https://twitter.com/MyPaoG), [LinkedIn](https://www.linkedin.com/in/mariapgg/)
-
 - Management: 1
 
   - Luis: [GitHub](https://github.com/luisivan), [Twitter](https://twitter.com/licuende)
-
 - Assistant: 1
 
   - Lorena: [Twitter](https://twitter.com/curritta), [LinkedIn](https://www.linkedin.com/in/lorenagonzalezmontes/)
-
-- Brand Design: 1
-
-  - Adri: [Twitter](https://twitter.com/owisixseven), [Behance](https://www.behance.net/owi_sixseven)
-
-- DevOps: 1 (part-time/contractor)
 
 ### Future openings
 
 We plan to hire for the following positions:
 
 - Frontend Developers: 4
-- Solidity Developers: 2
-- Web3 Developers: 2
+- Solidity Developers: 1
+- Web3 Developers: 1
 - Developer Relations: 1
+- Marketing/Growth Lead: 1
 
 That will take the team size to 25 people.
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -121,7 +121,7 @@ Make sure that aragonJS provides a much better [caching mechanism](https://githu
 
 #### 🔜 Experiment and implement centralized/decentralized hybrid for first-load
 
-Even enhancing aragonJS caching, the first load may still take a while. That's why it makes sense to experiment with centralized/decentralized hybrid solutions for it. For example, a trusted set of participants in the DAO could decide what the state was a at a given block, and then everyone would start loading from that. Then over time the client could sync locally and arrive to a fully decentralized/trustless state.
+Even enhancing aragonJS caching, the first load may still take a while. That's why it makes sense to experiment with centralized/decentralized hybrid solutions for it. For example, [a trusted set of participants in the DAO](https://forum.aragon.org/t/aragon-network-ipfs-pinning/824/25) could decide what the state was a at a given block, and then everyone would start loading from that. Then over time the client could sync locally and arrive to a fully decentralized/trustless state.
 
 ### 🔜 I10 – Email notifications
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -65,15 +65,11 @@ Focus areas for this initiative:
 
 [Related GitHub issue](https://github.com/aragon/aragonOS/issues/340)
 
-### I05 – Responsive experience
+### ✅ I05 – Responsive experience
 
 Improve the overall user experience of the platform and core apps by making the UI render well on any form factor, mobile wallet and browser, so users can seamlessly create, access and manage organizations.
 
-Focus areas for this initiative:
-
-- **✅ Responsive UI**: Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
-
-- **Native mobile app**: Build native (probably React Native makes the most sense) mobile Aragon clients so we can benefit from device and OS specific capabilities.
+Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
 
 [Related GitHub issue](https://github.com/aragon/design/issues/4)
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -117,7 +117,7 @@ ANT is intended to be used for governance and as the native currency for the net
 
 #### 🔜 Enhance aragonJS caching
 
-Make sure that aragonJS provides a much better caching mechanism, so the first load is slightly faster, and subsequent loads are much faster than they are now.
+Make sure that aragonJS provides a much better [caching mechanism](https://github.com/aragon/aragon.js/issues/294), so the first load is slightly faster, and subsequent loads are much faster than they are now.
 
 #### 🔜 Experiment and implement centralized/decentralized hybrid for first-load
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -19,7 +19,7 @@ The goal is to build an identity experience that is seamless and allows individu
 
 Focus areas for this initiative:
 
-- **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization.
+- ✅ **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization.
 
 - **Organization identity & membership support**: Allow users to create and manage their organizations’ profiles, providing an intuitive way to add members to a given organization and granting them permissions & privileges.
 
@@ -30,7 +30,7 @@ Related GitHub issues:
 <https://github.com/aragon/design/issues/13>
 <https://github.com/aragon/design/issues/5>
 
-### I02 – Agent application
+### 🔜 I02 – Agent application
 
 This application will enable organizations to interact natively with other web3 applications (including other Aragon organizations).
 
@@ -44,11 +44,8 @@ The App Center will allow users to discover, get and manage apps developed by Ar
 
 Focus areas for this initiative:
 
-- **Upgrading apps**: Provide users with a secure way to install new app versions, fixes for features or enhancements to already installed/in use apps.
-
+- ✅ **Upgrading apps**: Provide users with a secure way to install new app versions, fixes for features or enhancements to already installed/in use apps.
 - **Browsing, installing & uninstalling apps**: Enhance app discovery and app management for end users.
-
-- **Monetization/incentivisation model for app developers**: Provide app developers with different monetisation models to create revenue from the apps they publish in the Aragon App Center.
 
 Related GitHub issues: 
 <https://github.com/aragon/design/issues/17>
@@ -64,7 +61,7 @@ Focus areas for this initiative:
 
 - **UI for conditional permissions**: the ACL in aragonOS 4 supports conditional permissions through permission parametrization, the Permissions app should display and allow to edit parameters.
 
-- **Budgeting app**: Enable organizations to plan and control their financial resources by setting time based permissions like budgeting.
+- 🔜 **Budgeting app**: Enable organizations to plan and control their financial resources by setting time based permissions like budgeting.
 
 [Related GitHub issue](https://github.com/aragon/aragonOS/issues/340)
 
@@ -74,7 +71,7 @@ Improve the overall user experience of the platform and core apps by making the 
 
 Focus areas for this initiative:
 
-- **Responsive UI**: Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
+- **✅ Responsive UI**: Make the platform and core apps responsive so Aragon can be used from mobile browsers such as Status or Coinbase Wallet.
 
 - **Native mobile app**: Build native (probably React Native makes the most sense) mobile Aragon clients so we can benefit from device and OS specific capabilities.
 
@@ -86,8 +83,8 @@ The aim of this initiative is to lower the barrier of entry for adoption by allo
 
 Focus areas for this initiative:
 
-- Meta-transactions & relayers
-- Improving onboarding for organizations
+- 🔜 Meta-transactions & relayers
+- 🔜 Improving onboarding for organizations
 
 [Related GitHub issue](https://github.com/aragon/aragonOS/pull/442)
 
@@ -98,9 +95,7 @@ Redesign the current voting architecture and experience to accommodate new votin
 Focus areas for this initiative:
 
 - **Voting with ERC20 tokens**: Enable users to vote using ERC20 tokens.
-
 - **Solidify Research on Transaction and Vote relayers as a network service**: Current research has shown that Meta-transactions and EVM storage proofs could provide a way to improve the cost and user experience of voting by relying on a network of bonded transaction and vote relayers. This research would explore the potential of Transaction and Vote Relaying as another fee generating service maintained by the Aragon Network.
-
 - **UX & technical research**: Create a plan to research the needs and run a pilot with 0x – Use case: AGP-1 + Representative Council(s)
 - Research and develop new Voting mechanisms.
 
@@ -112,7 +107,7 @@ Aragon Agreements are a core component of the Aragon Network, they enable users 
 
 #### Proposal agreements
 
-Proposal Agreements enhance the Aragon Client enabling organizations to leverage agreements to improve governance outcomes by requiring members to collateralized an agreement in order to submit proposals. Subjective proposal agreements can help avoid 51% attacks in DAOs by making sure that only proposals that are valid by the organization’s charter can be voted on and executed.
+Proposal Agreements enhance the Aragon client enabling organizations to leverage agreements to improve governance outcomes by requiring members to collateralized an agreement in order to submit proposals. Subjective proposal agreements can help avoid 51% attacks in DAOs by making sure that only proposals that are valid by the organization’s charter can be voted on and executed.
 
 #### Aragon Court
 
@@ -122,9 +117,44 @@ The Aragon Court is a service protocol designed to incentivize honest arbitratio
 
 ANT is intended to be used for governance and as the native currency for the network. In order to optimize ANT for these uses adjustments to ANT’s monetary policy may be necessary. This research would (1) explore the impact of creating a liquidity reserve and treasury bonds to tightly couple the networks assets with the valuation of ANT and (2) the feasibility of shifting the realization value appreciation to unit count rather than unit price using a scalar value token structure.
 
+### I09 – Caching on the Aragon client
+
+#### 🔜 Enhance aragonJS caching
+
+Make sure that aragonJS provides a much better caching mechanism, so the first load is slightly faster, and subsequent loads are much faster than they are now.
+
+#### 🔜 Experiment and implement centralized/decentralized hybrid for first-load
+
+Even enhancing aragonJS caching, the first load may still take a while. That's why it makes sense to experiment with centralized/decentralized hybrid solutions for it. For example, a trusted set of participants in the DAO could decide what the state was a at a given block, and then everyone would start loading from that. Then over time the client could sync locally and arrive to a fully decentralized/trustless state.
+
+### 🔜 I10 – Email notifications
+
+All actions on DAOs are irreversible and some of them may involve funds, so notifications become very important to the DAO's stakeholders.
+
+We will implement opt-in notifications using an email server and another server which will track all DAO-related events on Ethereum.
+
+### 🔜 I11 – Aragon client re-design and general enhancements
+
+We plan to re-design the Aragon client by creating a new Aragon Human Interface Guidelines that standardizes how to create Aragon apps.
+
+As part of this re-design, we will also re-design the following items, based on user feedback:
+
+- The Permissions app
+- The Voting app
+
+### 🔜 I12 – Support Aragon Funraising development
+
+We commit to supporting [Aragon Black](https://github.com/aragon/flock/blob/master/teams/Aragon%20Black/2019%20-%20Q3%20%26%20Q4.md) on their efforts to create the Aragon Fundraising app.
+
+This includes:
+
+- Designing the whole app
+- Doing code reviews
+- Assist in implementing a fundraising template on the Aragon client
+
 ### aragonOS
 
-#### Global emergency failsafe
+#### 🔜 Global emergency failsafe
 
 Provide an opt-in failsafe for organizations and individual apps to safely freeze their state during times of emergency
 
@@ -140,7 +170,7 @@ Rather than being a core part of aragonOS, aragonPM is a use case that is built 
 
 ### aragonSDK
 
-#### Continuously improve developer experience
+#### ✅ Continuously improve developer experience
 
 We should reduce time for developers to start using the aragonSDK (<https://github.com/aragon/aragon-cli/issues/203>) and also add features they request to it.
 
@@ -148,11 +178,7 @@ We should reduce time for developers to start using the aragonSDK (<https://gith
 
 Provide more APIs for Aragon app developers to use, including both UI controls (e.g. notifications, toast messages) as well as messaging and data controls (e.g. network state, action triggers). Aragon apps should also be extended to allow for multiple contracts to be used with one frontend (“monolithic apps”).
 
-#### Split aragonUI and Lorikeet
-
-Push Lorikeet as an ecosystem-wide project, while still providing an Aragon-opinionated experience with aragonUI.
-
-#### Maintain developer documentation and port it over to the new website design system
+#### ✅ Maintain developer documentation and port it over to the new website design system
 
 Take care of reviewing developer documentation when needed, and design and implement a new developer portal that aligns with the current design system we use for aragon.org.
 
@@ -249,68 +275,50 @@ The team is fully remote and distributed across the world, primarily in Europe a
 
 ### Current team
 
-The current full-time team is comprised of 16 people, distributed as follows:
+The current full-time team is comprised of 17 people, distributed as follows:
 
-- Development: 6
+- Development: 7
 
   - Brett: [GitHub](https://github.com/sohkai)
   - Pierre: [GitHub](https://github.com/bpierre)
   - Bingen: [GitHub](https://github.com/bingen)
   - Delfi: [GitHub](https://github.com/delfipolito)
   - Gorka: [GitHub](https://github.com/AquiGorka)
-  - Paul: [GitHub](https://github.com/drcmda)
-
-- Product Management and UX: 1
-
-  - Paty: [Github](https://github.com/dizzypaty), [Twitter](https://twitter.com/dizzypaty), [website](http://patydavila.com/)
-
+  - Facu: [GitHub](https://github.com/facuspagnuolo)
+- Daniel: [GitHub](https://github.com/2color)
 - Community and Communications: 2
 
   - Tatu: [GitHub](https://github.com/Smokyish), [Twitter](https://twitter.com/Smokyish), [LinkedIn](https://www.linkedin.com/in/smokyish/)
   - John: [GitHub](https://github.com/john-light), [Twitter](https://twitter.com/lightcoin), [LinkedIn](https://www.linkedin.com/in/lightcoin/)
-  
 - HR: 1
   - Monica: [Twitter](https://twitter.com/monicazng), [LinkedIn](https://www.linkedin.com/in/roumonicazeng)
-
-- Ops: 1
-
-  - Alexa: [GitHub](https://github.com/alexarwr), [Twitter,](https://twitter.com/alexa_rwr) [LinkedIn](https://www.linkedin.com/in/alexarwr/)
-
 - Research: 2
 
-- - Jorge: [GitHub](https://github.com/izqui), [Twitter](https://twitter.com/izqui9)
+  - Jorge: [GitHub](https://github.com/izqui), [Twitter](https://twitter.com/izqui9)
   - Luke: [GitHub](https://github.com/lkngtn), [Twitter](https://twitter.com/lkngtn), [LinkedIn](https://www.linkedin.com/in/lukasduncan/)
+- Design: 2
 
-- Product Design: 1
-
-  - Jouni: [GitHub](https://github.com/jounih), [Twitter](https://twitter.com/dharmaone), [LinkedIn](https://www.linkedin.com/in/jounihelminen/)
-
+  - Paty: [Github](https://github.com/dizzypaty), [Twitter](https://twitter.com/dizzypaty), [website](https://www.linkedin.com/in/jounihelminen/)
+  - Adri: [Twitter](https://twitter.com/owisixseven), [Behance](https://www.behance.net/owi_sixseven)
 - Ecosystem Development: 1
 
   - Maria: [GitHub](https://github.com/mariapao), [Twitter](https://twitter.com/MyPaoG), [LinkedIn](https://www.linkedin.com/in/mariapgg/)
-
 - Management: 1
 
   - Luis: [GitHub](https://github.com/luisivan), [Twitter](https://twitter.com/licuende)
-
 - Assistant: 1
 
   - Lorena: [Twitter](https://twitter.com/curritta), [LinkedIn](https://www.linkedin.com/in/lorenagonzalezmontes/)
-
-- Brand Design: 1
-
-  - Adri: [Twitter](https://twitter.com/owisixseven), [Behance](https://www.behance.net/owi_sixseven)
-
-- DevOps: 1 (part-time/contractor)
 
 ### Future openings
 
 We plan to hire for the following positions:
 
 - Frontend Developers: 4
-- Solidity Developers: 2
-- Web3 Developers: 2
+- Solidity Developers: 1
+- Web3 Developers: 1
 - Developer Relations: 1
+- Marketing/Growth Lead: 1
 
 That will take the team size to 25 people.
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -19,8 +19,8 @@ The goal is to build an identity experience that is seamless and allows individu
 
 Focus areas for this initiative:
 
-- ✅ **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization.
-
+- ✅ **Custom labels**: Easily tag any Ethereum address on the client. Also easily share tags with other people via a file or a link.
+- 🔜 **Individual identity**: Allow individuals to create and manage their user profile, mapping their address to a human readable ENS name that can be used to interact with apps within the organization. [Autark](https://github.com/aragon/flock/blob/master/teams/Autark/2019Q1-2.md) is the one leading this initiative, and we will support via design and code reviews.
 - **Organization identity & membership support**: Allow users to create and manage their organizations’ profiles, providing an intuitive way to add members to a given organization and granting them permissions & privileges.
 
 Related GitHub issues:

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -138,7 +138,7 @@ As part of this re-design, we will also re-design the following items, based on 
 - The Permissions app
 - The Voting app
 
-### 🔜 I12 – Support Aragon Funraising development
+### 🔜 I12 – Support Aragon Fundraising development
 
 We commit to supporting [Aragon Black](https://github.com/aragon/flock/blob/master/teams/Aragon%20Black/2019%20-%20Q3%20%26%20Q4.md) on their efforts to create the Aragon Fundraising app.
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -162,7 +162,7 @@ Provide an opt-in failsafe for organizations and individual apps to safely freez
 
 As a new system built on highly experimental technology, it is highly desirable to include failsafes in the event of security breaches or other emergency events. Organizations should be able to opt-in their entire organization or a particular set of applications to a failsafe that freezes their state and execution when triggered.
 
-[Related GitHub issue](https://github.com/aragon/aragonOS/issues/151)
+[Related GitHub issue](https://github.com/aragon/aragonOS/pull/518)
 
 #### Decouple aragonPM implementation
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -131,7 +131,7 @@ We will implement opt-in notifications using an email server and another server 
 
 ### 🔜 I11 – Aragon client re-design and general enhancements
 
-We plan to re-design the Aragon client by creating a new Aragon Human Interface Guidelines that standardizes how to create Aragon apps.
+We plan to re-design the Aragon client by creating a new Aragon Human Interface Guideline that standardizes how to create Aragon apps.
 
 As part of this re-design, we will also re-design the following items, based on user feedback:
 

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -148,6 +148,12 @@ This includes:
 - Doing code reviews
 - Assist in implementing a fundraising template on the Aragon client
 
+### 🔜 I13 – Launch Aragon Payroll
+
+Crypto-native payroll has sparked a lot of interest, and we are contuing Protofire's work on [Aragon Payroll](https://github.com/aragon/aragon-apps/tree/master/future-apps/payroll) to finish it and start using it with early testers.
+
+While we commit to getting it to a beta state, the maintainance of it will have to be carefully considered since Aragon One may not have the bandwidth to maintain it.
+
 ### aragonOS
 
 #### 🔜 Global emergency failsafe

--- a/teams/Aragon One/2019.md
+++ b/teams/Aragon One/2019.md
@@ -150,7 +150,7 @@ This includes:
 
 ### 🔜 I13 – Launch Aragon Payroll
 
-Crypto-native payroll has sparked a lot of interest, and we are contuing Protofire's work on [Aragon Payroll](https://github.com/aragon/aragon-apps/tree/master/future-apps/payroll) to finish it and start using it with early testers.
+Crypto-native payroll has sparked a lot of interest, and we are continuing Protofire's work on [Aragon Payroll](https://github.com/aragon/aragon-apps/tree/master/future-apps/payroll) to finish it and start using it with early testers.
 
 While we commit to getting it to a beta state, the maintainance of it will have to be carefully considered since Aragon One may not have the bandwidth to maintain it.
 


### PR DESCRIPTION
*Note: This is a follow up to the previous PR that was accidentally unilaterally merged*

We want to update Aragon One's roadmap for 2019 to reflect on the following:
- Items that have been already delivered, and items that are on its way for the next quarter
- Removing a native mobile app from the scope for focus sake
- Removing Aragon app monetization since we first need users for the platform to be interesting for devs
- Adding caching, fundraising, notifications and Aragon client re-design to the scope
- Updating the team info